### PR TITLE
Docker build SHA output

### DIFF
--- a/src/dfbar/dfbar.py
+++ b/src/dfbar/dfbar.py
@@ -157,7 +157,7 @@ def process_docker_spec(
         logger.error(proc.stdout.decode("ascii"))
         return proc.returncode
 
-    docker_image = proc.stdout.decode("ascii").splitlines()[0]
+    docker_image = proc.stdout.decode("ascii").splitlines()[-1]
     logger.debug(f"Docker image SHA: {docker_image}")
 
     # Run the container image


### PR DESCRIPTION
Docker build output includes debug lines before SHA output. Changing to
use the last line of the quite output as a workaround. GitHub issue: https://github.com/docker/buildx/issues/3015
